### PR TITLE
Set the caller ID number when group dialing

### DIFF
--- a/app/Http/Controllers/TelephonyController.php
+++ b/app/Http/Controllers/TelephonyController.php
@@ -12,7 +12,7 @@ class TelephonyController extends Controller
 {
     public function twilio(Request $request, Group $group, Twilio $twilio)
     {
-        $group->load('users.phoneNumbers');
+        $twilio->setCallerIdNumber($request->get('to'));
 
         return response($twilio->groupDial($group->getAvailableNumbers()))
             ->header('Content-Type', 'application/xml');

--- a/app/Services/Telephony/AbstractTelephonyProvider.php
+++ b/app/Services/Telephony/AbstractTelephonyProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services\Telephony;
+
+use App\Contracts\TelephonyProvider;
+
+abstract class AbstractTelephonyProvider implements TelephonyProvider
+{
+    /**
+     * @var string The caller ID number to use when routing calls.
+     */
+    protected $callerIdNumber;
+
+    /**
+     * Set the caller ID number.
+     *
+     * @param string $number The E.164 caller ID number.
+     *
+     * @todo Validate the callback number before setting.
+     */
+    public function setCallerIdNumber(string $number)
+    {
+        $this->callerIdNumber = $number;
+    }
+}

--- a/app/Services/Telephony/Twilio.php
+++ b/app/Services/Telephony/Twilio.php
@@ -6,7 +6,7 @@ use App\Contracts\TelephonyProvider;
 use Illuminate\Support\Collection;
 use Twilio\Twiml;
 
-class Twilio implements TelephonyProvider
+class Twilio extends AbstractTelephonyProvider
 {
     /**
      * @var \Twilio\Twiml $twiml
@@ -29,7 +29,9 @@ class Twilio implements TelephonyProvider
      */
     public function groupDial(Collection $numbers)
     {
-        $dial = $this->twiml->dial();
+        $dial = $this->twiml->dial(array_filter([
+            'callerId' => $this->callerIdNumber,
+        ]));
 
         $numbers->take(10)->each(function ($number) use ($dial) {
             $dial->number($number->number);

--- a/tests/Feature/TelephonyTest.php
+++ b/tests/Feature/TelephonyTest.php
@@ -26,6 +26,7 @@ class TelephonyTest extends TestCase
         ]);
 
         $response->assertHeader('Content-Type', 'application/xml');
+        $response->assertSee('<Dial callerId="' . $phoneNumber->number . '">');
 
         foreach ($group->getAvailableNumbers() as $number) {
             $response->assertSee('<Number>' . $number->number . '</Number>');

--- a/tests/Unit/Services/Telephony/AbstractTelephonyProviderTest.php
+++ b/tests/Unit/Services/Telephony/AbstractTelephonyProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Services\Telephony;
+
+use App\Services\Telephony\AbstractTelephonyProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AbstractTelephonyProviderTest extends TestCase
+{
+    public function testSetCallerIdNumber()
+    {
+        $mock = $this->getMockForAbstractClass(AbstractTelephonyProvider::class);
+        $prop = new \ReflectionProperty(AbstractTelephonyProvider::class, 'callerIdNumber');
+        $prop->setAccessible(true);
+
+        $mock->setCallerIdNumber('+15558675309');
+
+        $this->assertSame('+15558675309', $prop->getValue($mock));
+    }
+
+    public function testSetCallerIdNumberValidatesE164Format()
+    {
+        $this->markTestIncomplete('E.164 format validation has not yet been implemented.');
+    }
+}


### PR DESCRIPTION
This PR introduces the `AbstractTelephonyProvider` class, which all other telephony providers should extend. In it, a common `setCallerIdNumber()` method is defined, which lets the caller ID number be set for calls sent out to groups of volunteers.

Fixes #10.